### PR TITLE
fixed ylabel bug

### DIFF
--- a/seeq/addons/plot_curve/ui_components/_chart_component.py
+++ b/seeq/addons/plot_curve/ui_components/_chart_component.py
@@ -155,7 +155,7 @@ class ChartComponent(vue.VuetifyTemplate):
         x_units = self.get_active_equation_parameter('x_units')
         y_units = self.get_active_equation_parameter('y_units')
         independent_variable = self.get_active_equation_parameter('independent_variable')
-        dependent_variable = self.get_active_equation_parameter('independent_variable')
+        dependent_variable = self.get_active_equation_parameter('dependent_variable')
 
         figure = plt.figure()
         figure.layout.min_height = '300px'


### PR DESCRIPTION
This PR fixes a bug in the _chart_component.  There was a typo causing the dependent variable label to reference the independent variable instead of the dependent variable.

Closes #3 