### PR TITLE
Feature/rwd/warn on no exponent carat

### DIFF
--- a/seeq/addons/plot_curve/backend/_backend.py
+++ b/seeq/addons/plot_curve/backend/_backend.py
@@ -123,6 +123,15 @@ class BackEnd:
         return df
 
     def _validate_unit(self, unit):
+
+        contains_number = any(char.isdigit() for char in unit)
+        contains_exp = '^' in unit
+        if contains_number and not contains_exp:
+            self.message_events.on_next({'type': MessageType.ERROR,
+                                         'message': f'The unit {unit} contains a number but no exponent.  '
+                                                    f'Seeq uses ^ to indicate an exponent.  Before proceeding, '
+                                                    f'please check the units in your data.'})
+
         base_unit = ''.join([i for i in unit if not i.isdigit()]).replace('**', '').replace('^', '')
         if base_unit is not '%':
             try:

--- a/seeq/addons/plot_curve/backend/_equation.py
+++ b/seeq/addons/plot_curve/backend/_equation.py
@@ -69,8 +69,8 @@ class Equation:
     @tracker(project=__name__)
     def seeq_formula(self):
         conversion = f"$converted_signal = $signal.convertUnits('{self.x_units}').setUnits('')"
-        splice = f"$splicedSignal = $converted_signal.remove($converted_signal." \
-                 f"isNotBetween({str(min(self.x_data))}, {str(max(self.x_data))}))"
+        splice = (f"$splicedSignal = $converted_signal.remove($converted_signal."
+                  f"isNotBetween({str(min(self.x_data))}, {str(max(self.x_data))}))")
         exponents = list(range(len(self._fit_coefficients)))
         exponents.reverse()
         terms = list()

--- a/seeq/addons/plot_curve/backend/_equation.py
+++ b/seeq/addons/plot_curve/backend/_equation.py
@@ -68,8 +68,9 @@ class Equation:
     @property
     @tracker(project=__name__)
     def seeq_formula(self):
-        splice = f"$splicedSignal = $signal.remove($signal.isNotBetween({str(min(self.x_data))}," \
-                 f"{str(max(self.x_data))})).convertUnits('{self.x_units}').setUnits('')"
+        conversion = f"$converted_signal = $signal.convertUnits('{self.x_units}').setUnits('')"
+        splice = f"$splicedSignal = $converted_signal.remove($converted_signal." \
+                 f"isNotBetween({str(min(self.x_data))}, {str(max(self.x_data))}))"
         exponents = list(range(len(self._fit_coefficients)))
         exponents.reverse()
         terms = list()
@@ -78,7 +79,7 @@ class Equation:
 
         equation_expression = '(' + ' + '.join(terms) + f").setunits('{self.y_units}')"
 
-        return splice + '\n' + equation_expression
+        return conversion + '\n' + splice + '\n' + equation_expression
 
     @property
     @tracker(project=__name__)

--- a/seeq/addons/plot_curve/ui_components/_chart_component.py
+++ b/seeq/addons/plot_curve/ui_components/_chart_component.py
@@ -155,7 +155,7 @@ class ChartComponent(vue.VuetifyTemplate):
         x_units = self.get_active_equation_parameter('x_units')
         y_units = self.get_active_equation_parameter('y_units')
         independent_variable = self.get_active_equation_parameter('independent_variable')
-        dependent_variable = self.get_active_equation_parameter('independent_variable')
+        dependent_variable = self.get_active_equation_parameter('dependent_variable')
 
         figure = plt.figure()
         figure.layout.min_height = '300px'

--- a/seeq/addons/plot_curve/ui_components/templates/AppLayout.vue
+++ b/seeq/addons/plot_curve/ui_components/templates/AppLayout.vue
@@ -34,7 +34,9 @@
                 <br/><br/>
                 The format of the csv file is as follows.  The first column indicates which curve the data in that row is assigned to. The remaining columns
                 represent data for that particular curve. Units are provided in the second row.  The below example, shows a csv with a single curve (Pump Curve 1),
-                and two parameters (Flow and Head).  The bold items (Curve and Units) are optional, but recommended to indicate <b>required</b> headers.
+                and two parameters (Flow and Head).  Note that units with exponents require the use of the `^` symbol to denote exponent.
+
+                The bold items (Curve and Units) are optional, but recommended to indicate <b>required</b> headers.
 
                 Automated conversion of units is handled by Seeq provided the
                 <a href='https://seeq.atlassian.net/wiki/spaces/KB/pages/112761878/Units+of+Measure+UOM' target='_blank'>units are supported</a>.
@@ -51,7 +53,7 @@
                   <tbody>
                   <tr>
                     <td color='red'><b>Units</b></td>
-                    <td>m3/hr</td>
+                    <td>m^3/hr</td>
                     <td>m</td>
                   </tr>
                   <tr>


### PR DESCRIPTION
Units in seeq require use of the carat (^) symbol for exponents.  This PR checks if the units contain a digit in them, and if so but no carat symbol, provides a targeted message to indicate/warn the user.

Closes #2 