### PR TITLE
Bugfix/rwd/equation splice order

### DIFF
--- a/seeq/addons/plot_curve/backend/_equation.py
+++ b/seeq/addons/plot_curve/backend/_equation.py
@@ -68,8 +68,9 @@ class Equation:
     @property
     @tracker(project=__name__)
     def seeq_formula(self):
-        splice = f"$splicedSignal = $signal.remove($signal.isNotBetween({str(min(self.x_data))}," \
-                 f"{str(max(self.x_data))})).convertUnits('{self.x_units}').setUnits('')"
+        conversion = f"$converted_signal = $signal.convertUnits('{self.x_units}').setUnits('')"
+        splice = f"$splicedSignal = $converted_signal.remove($converted_signal." \
+                 f"isNotBetween({str(min(self.x_data))}, {str(max(self.x_data))}))"
         exponents = list(range(len(self._fit_coefficients)))
         exponents.reverse()
         terms = list()
@@ -78,7 +79,7 @@ class Equation:
 
         equation_expression = '(' + ' + '.join(terms) + f").setunits('{self.y_units}')"
 
-        return splice + '\n' + equation_expression
+        return conversion + '\n' + splice + '\n' + equation_expression
 
     @property
     @tracker(project=__name__)

--- a/seeq/addons/plot_curve/ui_components/_chart_component.py
+++ b/seeq/addons/plot_curve/ui_components/_chart_component.py
@@ -155,7 +155,7 @@ class ChartComponent(vue.VuetifyTemplate):
         x_units = self.get_active_equation_parameter('x_units')
         y_units = self.get_active_equation_parameter('y_units')
         independent_variable = self.get_active_equation_parameter('independent_variable')
-        dependent_variable = self.get_active_equation_parameter('independent_variable')
+        dependent_variable = self.get_active_equation_parameter('dependent_variable')
 
         figure = plt.figure()
         figure.layout.min_height = '300px'


### PR DESCRIPTION
There was a bug in the formula that was being generated with respect to order of operations.  The $signal.remove() portion of the formula is intended to only calculate values that are within the curve fitted from the tabular data.  Previously, this $signal.remove was being done on the seeq signal, prior to unit conversion.  This PR modifies this, so that we first convert from the Seeq units to the units of the tabular data, and only then do we remove the portion of the signal that is outside of the curve.

Closes #4 