### PR TITLE
CRAB-39547: Package plot-curve for Add-on Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ generate the documentation in the docs folder, i.e.:
 $ make.bat github
 ```
 
+# Generating a .addon file for use with Add-on Manager 
+To create a .addon, run `python package.py` from the top directory after pip installing all the requirements in requirements.txt (`pip install -r requirements.txt`). It will produce a .addon file in the same directory.
+
 
 # Important links
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ If you want to install **seeq-plot-curve** as a Seeq Add-on Tool, you will need 
    app notebook which will be available from the deployment folder in Seeq Data Lab.
 4. Verify that the Plot Curve add-on is present in the AddOn menu in workbench.
 
-### Source Installation
+# Development -- Generating a .addon file for drag and droo use with Add-on Manager 
+To create a .addon, run `python package.py` from the top directory after pip installing all the requirements in requirements.txt (`pip install -r requirements.txt`). It will produce a .addon file in the same directory.
+
+# Installation 
+From the Add-on Manager UI, locate the name of the Add-on and click "Install". As of 10/27/2023, this is only available to users with access to the seeq-add-ons-dev-local Jfrog gallery. If you do not have access, use the deprecated source installation steps below.
+
+### DEPRECATED - Source Installation
 
 For development work, it is highly recommended creating a python virtual environment and install the package in that
 working environment. If you are not familiar with python virtual environments, you can take a
@@ -35,7 +41,7 @@ python setup.py install
 
 ----
 
-# Development
+# DEPRECATED - Development
 
 We welcome new contributors of all experience levels.
 
@@ -68,10 +74,6 @@ generate the documentation in the docs folder, i.e.:
 ```sh
 $ make.bat github
 ```
-
-# Generating a .addon file for use with Add-on Manager 
-To create a .addon, run `python package.py` from the top directory after pip installing all the requirements in requirements.txt (`pip install -r requirements.txt`). It will produce a .addon file in the same directory.
-
 
 # Important links
 

--- a/addon.json
+++ b/addon.json
@@ -1,0 +1,73 @@
+{
+    "identifier": "com.seeq.addons.plot_curve",
+    "name": "Plot Curve",
+    "description": "A tool for fitting curves to tabular data and pushing resulting formulas to Seeq",
+    "version": "1.0.0",
+    "license": "Seeq",
+    "icon": "fa fa-edit",
+    "tags": {
+        "maintainer": "Seeq"
+    },
+    "previews": [],
+    "elements": [
+        {
+            "name": "Plot Curve",
+            "identifier": "com.seeq.addons.plot_curve.datalabfunctions",
+            "description":"A tool for fitting curves to tabular data and pushing resulting formulas to Seeq",
+            "type": "AddOnTool",
+            "path": "data-lab-functions",
+            "notebook_file_path": "PlotCurve.ipynb",
+            "configuration_schema": {
+                "type": "object",
+                "properties": {
+                    "display": {
+                        "type": "object",
+                        "properties": {
+                            "icon": {
+                                "type": "string",
+                                "default": "fa fa-line-chart"
+                            },
+                            "linkType": {
+                                "enum": [
+                                    "window",
+                                    "tab",
+                                    "none"
+                                ],
+                                "default": "window"
+                            },
+                            "sortKey": {
+                                "type": "string",
+                                "default": "a"
+                            },
+                            "windowDetails": {
+                                "type": "string",
+                                "default": "popup=1,toolbar=0,location=0,left=800,top=200,height=915,width=1200"
+                            },
+                            "reuseWindow": {
+                                "type": "boolean",
+                                "default": false
+                            },
+                            "includeWorkbookParameters": {
+                                "type": "boolean",
+                                "default": true
+                            }
+                        },
+                        "required": [
+                            "icon",
+                            "linkType",
+                            "sortKey",
+                            "windowDetails",
+                            "reuseWindow",
+                            "includeWorkbookParameters"
+                        ]
+                    }
+                },
+                "required": [
+                    "display"
+                ]
+            },
+            "configuration_filename": "config",
+            "configuration_converter": "toml"
+        }
+    ]
+}

--- a/addon.json
+++ b/addon.json
@@ -4,19 +4,17 @@
     "description": "A tool for fitting curves to tabular data and pushing resulting formulas to Seeq",
     "version": "1.0.0",
     "license": "Seeq",
-    "icon": "fa fa-edit",
-    "tags": {
-        "maintainer": "Seeq"
-    },
+    "icon": "fa fa-line-chart",
+    "maintainer": "Seeq",
     "previews": [],
     "elements": [
         {
             "name": "Plot Curve",
-            "identifier": "com.seeq.addons.plot_curve.datalabfunctions",
+            "identifier": "com.seeq.addons.plot_curve.tool",
             "known_aliases": ["PlotCurve", "Plot Curve"],
             "description":"A tool for fitting curves to tabular data and pushing resulting formulas to Seeq",
             "type": "AddOnTool",
-            "path": "data-lab-functions",
+            "path": "add-on-tool",
             "notebook_file_path": "PlotCurve.ipynb",
             "configuration_schema": {
                 "type": "object",

--- a/addon.json
+++ b/addon.json
@@ -2,7 +2,7 @@
     "identifier": "com.seeq.addons.plot_curve",
     "name": "Plot Curve",
     "description": "A tool for fitting curves to tabular data and pushing resulting formulas to Seeq",
-    "version": "1.0.0",
+    "version": "0.1.3",
     "license": "Seeq",
     "icon": "fa fa-line-chart",
     "maintainer": "Seeq",
@@ -11,8 +11,11 @@
         {
             "name": "Plot Curve",
             "identifier": "com.seeq.addons.plot_curve.tool",
-            "known_aliases": ["PlotCurve", "Plot Curve"],
-            "description":"A tool for fitting curves to tabular data and pushing resulting formulas to Seeq",
+            "known_aliases": [
+                "PlotCurve",
+                "Plot Curve"
+            ],
+            "description": "A tool for fitting curves to tabular data and pushing resulting formulas to Seeq",
             "type": "AddOnTool",
             "path": "add-on-tool",
             "notebook_file_path": "PlotCurve.ipynb",

--- a/addon.json
+++ b/addon.json
@@ -13,6 +13,7 @@
         {
             "name": "Plot Curve",
             "identifier": "com.seeq.addons.plot_curve.datalabfunctions",
+            "known_aliases": ["PlotCurve", "Plot Curve"],
             "description":"A tool for fitting curves to tabular data and pushing resulting formulas to Seeq",
             "type": "AddOnTool",
             "path": "data-lab-functions",

--- a/package.py
+++ b/package.py
@@ -60,7 +60,7 @@ def setup_environment():
 def build_backend(): 
     print("Building the backend")
     build_results = subprocess.run(
-        ['python','setup.py','bdist_wheel'],
+        ['python3','setup.py','bdist_wheel'],
         cwd=PARENT_DIR, #only works locally
         **subprocess_kwargs
     )
@@ -141,7 +141,7 @@ def create_addonmetadata():
 def test_packaging(): 
     print("Testing the seeq-plot-curve package")
     test_results = subprocess.run(
-        ['python','test_package.py'],
+        ['python3','test_package.py'],
         cwd=PARENT_DIR
     )
     if test_results.returncode:

--- a/package.py
+++ b/package.py
@@ -60,7 +60,7 @@ def setup_environment():
 def build_backend(): 
     print("Building the backend")
     build_results = subprocess.run(
-        ['python3','setup.py','bdist_wheel'],
+        ['python','setup.py','bdist_wheel'],
         cwd=PARENT_DIR, #only works locally
         **subprocess_kwargs
     )
@@ -80,7 +80,7 @@ def build_backend():
 
 def generate_requirements_txt():
     print("Generating backend requirements.txt file")
-    path = PARENT_DIR / "temp_folder/data-lab-functions/requirements.txt"
+    path = PARENT_DIR / "temp_folder/add-on-tool/requirements.txt"
     path.parent.mkdir(parents=True, exist_ok=True)
     requirements = 'seeq_plot_curve-'+__version__+'-py3-none-any.whl'
 
@@ -93,8 +93,8 @@ def generate_requirements_txt():
         print("Failed to generate backend requirements.txt")
  
 paths = [
-    [PARENT_DIR/('dist/seeq_plot_curve-'+__version__+'-py3-none-any.whl'), PARENT_DIR/(('temp_folder/data-lab-functions/seeq_plot_curve-'+__version__+'-py3-none-any.whl'))],
-    [PARENT_DIR/'seeq/addons/plot_curve/deployment_notebook/PlotCurve.ipynb',PARENT_DIR/'temp_folder/data-lab-functions/PlotCurve.ipynb'],
+    [PARENT_DIR/('dist/seeq_plot_curve-'+__version__+'-py3-none-any.whl'), PARENT_DIR/(('temp_folder/add-on-tool/seeq_plot_curve-'+__version__+'-py3-none-any.whl'))],
+    [PARENT_DIR/'seeq/addons/plot_curve/deployment_notebook/PlotCurve.ipynb',PARENT_DIR/'temp_folder/add-on-tool/PlotCurve.ipynb'],
     [PARENT_DIR/ 'addon.json',PARENT_DIR/'temp_folder/addon.json']
 ]
 
@@ -126,7 +126,6 @@ def zip_items():
             for file in files:
                 fileName = root + "/"+ file
                 fileName = Path(fileName)
-                print("filename isS: ", fileName)
                 relPath = os.path.relpath(fileName, PARENT_DIR/'temp_folder').replace('\\','/')
                 print("Writing: " , relPath)
                 relPath = Path(relPath) 
@@ -142,7 +141,7 @@ def create_addonmetadata():
 def test_packaging(): 
     print("Testing the seeq-plot-curve package")
     test_results = subprocess.run(
-        ['python3','test_package.py'],
+        ['python','test_package.py'],
         cwd=PARENT_DIR
     )
     if test_results.returncode:

--- a/package.py
+++ b/package.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import subprocess
 import sys
-# from artifactory import ArtifactoryPath
 from pathlib import Path
 from seeq.addons.plot_curve import __version__
 from zipfile import ZipFile
@@ -61,7 +60,7 @@ def setup_environment():
 def build_backend(): 
     print("Building the backend")
     build_results = subprocess.run(
-        ['python','setup.py','bdist_wheel'],
+        ['python3','setup.py','bdist_wheel'],
         cwd=PARENT_DIR, #only works locally
         **subprocess_kwargs
     )
@@ -143,7 +142,7 @@ def create_addonmetadata():
 def test_packaging(): 
     print("Testing the seeq-plot-curve package")
     test_results = subprocess.run(
-        ['python','test_package.py'],
+        ['python3','test_package.py'],
         cwd=PARENT_DIR
     )
     if test_results.returncode:

--- a/package.py
+++ b/package.py
@@ -61,7 +61,7 @@ def setup_environment():
 def build_backend(): 
     print("Building the backend")
     build_results = subprocess.run(
-        ['python3','setup.py','bdist_wheel'],
+        ['python','setup.py','bdist_wheel'],
         cwd=PARENT_DIR, #only works locally
         **subprocess_kwargs
     )
@@ -141,7 +141,15 @@ def create_addonmetadata():
                   arcname='addon.json')
 
 def test_packaging(): 
-    print("Testing will be added post initial PR ")
+    print("Testing the seeq-plot-curve package")
+    test_results = subprocess.run(
+        ['python','test_package.py'],
+        cwd=PARENT_DIR
+    )
+    if test_results.returncode:
+        log_build_error(build_logger,test_results)
+        sys.exit(test_results.returncode)
+    
 
 if __name__ == "__main__" : 
     cleanup()
@@ -151,4 +159,4 @@ if __name__ == "__main__" :
     move_artifacts()
     zip_items()
     create_addonmetadata()
-    # test_packaging() 
+    test_packaging() 

--- a/package.py
+++ b/package.py
@@ -86,7 +86,7 @@ def setup_environment():
 def build_backend(): 
     print("Building the backend")
     build_results = subprocess.run(
-        ['python','setup.py','bdist_wheel'],
+        ['python3','setup.py','bdist_wheel'],
         cwd=PARENT_DIR, #only works locally
         **subprocess_kwargs
     )
@@ -167,7 +167,7 @@ def create_addonmetadata():
 def test_packaging(): 
     print("Testing the seeq-plot-curve package")
     test_results = subprocess.run(
-        ['python','test_package.py'],
+        ['python3','test_package.py'],
         cwd=PARENT_DIR
     )
     if test_results.returncode:

--- a/package.py
+++ b/package.py
@@ -1,0 +1,154 @@
+import logging 
+import os
+import shutil
+import subprocess
+import sys
+# from artifactory import ArtifactoryPath
+from pathlib import Path
+from seeq.addons.plot_curve import __version__
+from zipfile import ZipFile
+
+build_logger = logging.getLogger('build')
+build_logger.addHandler(logging.StreamHandler())
+
+PARENT_DIR = Path(__file__).resolve().parent
+ADDON = "seeq_plot_curve"
+custom_env = {"PATH": os.environ.get("PATH")}
+
+subprocess_kwargs = {
+    'capture_output': True,
+}
+
+
+def log_build_error(logger, results):
+    logger.error(
+        results.stderr.decode('utf-8')
+        if results.stderr
+        else f'Error running build script for {ADDON}'
+    )
+
+def cleanup():
+    temp_folder_path = PARENT_DIR/"temp_folder"
+    try:
+        shutil.rmtree(temp_folder_path)
+        if(not os.path.exists(PARENT_DIR/"temp_folder/")):
+            print("Successfully removed temp_folder")
+    except FileNotFoundError:
+        print("Attempting clean up unnecessary. No temp_folder/ found at: ", temp_folder_path)
+
+    dist_folder=PARENT_DIR/"dist"
+    try:
+        shutil.rmtree(dist_folder)
+        if(not os.path.exists(PARENT_DIR/"dist/")):
+            print("Successfully removed dist_folder")
+    except FileNotFoundError:
+        print("Attempting clean up unnecessary. No temp_folder/ found at: ", dist_folder)
+
+def setup_environment():
+    requirements_results = subprocess.run(
+        ['pip','install','-r', 'requirements.txt'],
+        cwd=PARENT_DIR,
+        **subprocess_kwargs
+    )
+
+    if requirements_results.returncode:
+        log_build_error(build_logger,requirements_results)
+        sys.exit(requirements_results.returncode)
+        
+    print('Environment setup complete')
+        
+
+def build_backend(): 
+    print("Building the backend")
+    build_results = subprocess.run(
+        ['python3','setup.py','bdist_wheel'],
+        cwd=PARENT_DIR, #only works locally
+        **subprocess_kwargs
+    )
+
+    if build_results.returncode:
+        log_build_error(build_logger,build_results)
+        sys.exit(build_results.returncode)
+    
+    expected_whl_path = PARENT_DIR/('dist/seeq_plot_curve-'+__version__+'-py3-none-any.whl')
+    if os.path.exists(expected_whl_path):
+        print(".whl generated at: ", expected_whl_path)
+    else:
+        error_message = "failed to generate: " + str(expected_whl_path)
+        raise FileNotFoundError(error_message) 
+    
+    print('Building backend complete')
+
+def generate_requirements_txt():
+    print("Generating backend requirements.txt file")
+    path = PARENT_DIR / "temp_folder/data-lab-functions/requirements.txt"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    requirements = 'seeq_plot_curve-'+__version__+'-py3-none-any.whl'
+
+    with open(path, 'w') as f:
+        f.write(requirements)
+
+    if path.exists():
+        print("Successfully generated backend requirements.txt")
+    else:
+        print("Failed to generate backend requirements.txt")
+ 
+paths = [
+    [PARENT_DIR/('dist/seeq_plot_curve-'+__version__+'-py3-none-any.whl'), PARENT_DIR/(('temp_folder/data-lab-functions/seeq_plot_curve-'+__version__+'-py3-none-any.whl'))],
+    [PARENT_DIR/'seeq/addons/plot_curve/deployment_notebook/PlotCurve.ipynb',PARENT_DIR/'temp_folder/data-lab-functions/PlotCurve.ipynb'],
+    [PARENT_DIR/ 'addon.json',PARENT_DIR/'temp_folder/addon.json']
+]
+
+def move_artifacts():
+    build_logger.info("Moving artifacts into .addon directory:")
+    for artifact in paths:
+        print("Copying ,", artifact[0],"to ", artifact[1])
+        current_path = artifact[0]
+        new_path = artifact[1]
+        if current_path.is_dir():
+            shutil.copytree(str(current_path), str(new_path))
+        else:
+            new_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(str(current_path), str(new_path))
+
+        if new_path.exists():
+            build_logger.info(f"\t{current_path} moved successfully to {new_path}")
+        else:
+            build_logger.error(f'\t{current_path} failed to move to {new_path}')
+
+
+def zip_items():
+    zipName = "seeq-plot-curve-" + __version__ + ".addon"
+    print ("Zipping files into", zipName)
+
+    with ZipFile(zipName, 'w') as zip:
+        for root, dirs, files in os.walk(PARENT_DIR/'temp_folder', topdown=True):
+
+            for file in files:
+                fileName = root + "/"+ file
+                fileName = Path(fileName)
+                print("filename isS: ", fileName)
+                relPath = os.path.relpath(fileName, PARENT_DIR/'temp_folder').replace('\\','/')
+                print("Writing: " , relPath)
+                relPath = Path(relPath) 
+                zip.write(fileName, arcname = relPath)
+
+def create_addonmetadata(): 
+    addon_path = PARENT_DIR/ 'addon.json'
+    zipName = "seeq-plot-curve-" + __version__ + ".addonmeta"
+    with ZipFile(zipName, 'w') as zip: 
+        zip.write(addon_path, 
+                  arcname='addon.json')
+
+def test_packaging(): 
+    print("Testing will be added post initial PR ")
+
+if __name__ == "__main__" : 
+    cleanup()
+    setup_environment()
+    build_backend() 
+    generate_requirements_txt()
+    move_artifacts()
+    zip_items()
+    create_addonmetadata()
+    # test_packaging() 

--- a/package.py
+++ b/package.py
@@ -26,7 +26,7 @@ def configure_version():
     final_version = current_version
     # This step will capture version changes in seeq.addons.plot_curve.__version__
     # but the addon.json file still will need manual update as good practice for version control 
-    if current_version < new_version: 
+    if current_version != new_version: 
         data['version'] = new_version
         final_version = new_version
         print("Updating addon version to version: ", new_version)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ setuptools~=57.4.0
 mixpanel>=4.9.0
 typeguard>=2.13.0
 pint>=0.17.0
+dohq-artifactory==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,3 @@ setuptools~=57.4.0
 mixpanel>=4.9.0
 typeguard>=2.13.0
 pint>=0.17.0
-dohq-artifactory==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 seeq
+seeq-spy
 ipywidgets >= 7.6.3
 numpy >= 1.19.5
 pandas >= 1.2.3, != 1.3.0

--- a/test_package.py
+++ b/test_package.py
@@ -21,16 +21,21 @@ def configure_version():
     
     current_version = data['version']
     new_version = __version__
+    print("Existing addon version: ", current_version, " incoming addon version: ", new_version)
     final_version = current_version
-    if current_version < new_version:
+    # This step will capture version changes in seeq.addons.plot_curve.__version__
+    # but the addon.json file still will need manual update as good practice for version control 
+    if current_version < new_version: 
         data['version'] = new_version
         final_version = new_version
+        print("Updating addon version to version: ", new_version)
+    else:
+        print("Updating addon version unnecessary")
 
     with open('addon.json', 'w') as file: 
         data = json.dump(data, file)
     
     return final_version 
-    
 
 version = configure_version()
 

--- a/test_package.py
+++ b/test_package.py
@@ -1,0 +1,67 @@
+import logging
+import os
+import shutil
+from seeq.addons.plot_curve import __version__
+from pathlib import Path
+from zipfile import ZipFile
+
+ADDON = "seeq_plot_curve"
+build_logger = logging.getLogger('build')
+build_logger.addHandler(logging.StreamHandler())
+
+
+PARENT_DIR = Path(__file__).resolve().parent
+TEMP_DIR = PARENT_DIR/"temp_folder"
+
+
+final_artifacts = ['data-lab-functions/PlotCurve.ipynb',
+    ('data-lab-functions/seeq_plot_curve-'+__version__+'-py3-none-any.whl'),
+    'data-lab-functions/requirements.txt',
+    'addon.json']
+
+def test_temp_directory():
+    print("Running tests on pre-zipped package")
+    count = 0
+    for artifact in final_artifacts:
+        temp = TEMP_DIR/artifact
+        assert Path.exists(temp), ("Test failure, failed to locate: " + str(artifact) + " in final package")
+        count+=1
+    print("Packaging smoke test verified presence all", count, "of", count, "artifacts for addon: ", ADDON, "in the pre-zipped archive")
+
+
+def test_zipped_package():
+    print("Runing tests on zipped package")
+    version = __version__
+    zipName = "seeq-plot-curve-" + version + ".addon"
+    print ("Extracting zipping files into", zipName)
+
+    zipPath = PARENT_DIR/('seeq-plot-curve-'+version+'.addon')
+
+    if not zipPath.exists():
+        raise Exception("seeq-plot-curve-" + version + ".addon to be used for extraction does not exist")
+
+    with ZipFile(zipPath, 'r') as zip_ref:
+        target_dir = "test_temp_dir"
+        os.makedirs(target_dir, exist_ok =True)
+
+        zip_ref.extractall(target_dir)
+
+    count = 0
+    for artifact in final_artifacts:
+        temp = Path("test_temp_dir")
+        assert Path.exists(temp/ artifact), ("Test failure, failed to locate: " + str(artifact) + " in final package")
+        count+=1
+    print("Packaging smoke test verified presence all", count, "of", count, "artifacts for addon: ", ADDON, " in the final archive.")
+
+    temp_folder_path = "test_temp_dir"
+    try:
+        shutil.rmtree(temp_folder_path)
+        if(not os.path.exists("temp_folder/")):
+            print("Successfully removed temp_folder")
+    except FileNotFoundError:
+        print("Attempting clean up unsuccessful. No temp_folder/ found in: ", ADDON)
+
+
+if __name__ =="__main__":
+    test_temp_directory()
+    test_zipped_package()

--- a/test_package.py
+++ b/test_package.py
@@ -14,9 +14,9 @@ PARENT_DIR = Path(__file__).resolve().parent
 TEMP_DIR = PARENT_DIR/"temp_folder"
 
 
-final_artifacts = ['data-lab-functions/PlotCurve.ipynb',
-    ('data-lab-functions/seeq_plot_curve-'+__version__+'-py3-none-any.whl'),
-    'data-lab-functions/requirements.txt',
+final_artifacts = ['add-on-tool/PlotCurve.ipynb',
+    ('add-on-tool/seeq_plot_curve-'+__version__+'-py3-none-any.whl'),
+    'add-on-tool/requirements.txt',
     'addon.json']
 
 def test_temp_directory():

--- a/test_package.py
+++ b/test_package.py
@@ -1,4 +1,5 @@
 import logging
+import json
 import os
 import shutil
 from seeq.addons.plot_curve import __version__
@@ -12,6 +13,26 @@ build_logger.addHandler(logging.StreamHandler())
 
 PARENT_DIR = Path(__file__).resolve().parent
 TEMP_DIR = PARENT_DIR/"temp_folder"
+
+def configure_version(): 
+    data = None
+    with open ('addon.json', 'r') as file: 
+        data = json.load(file)
+    
+    current_version = data['version']
+    new_version = __version__
+    final_version = current_version
+    if current_version < new_version:
+        data['version'] = new_version
+        final_version = new_version
+
+    with open('addon.json', 'w') as file: 
+        data = json.dump(data, file)
+    
+    return final_version 
+    
+
+version = configure_version()
 
 
 final_artifacts = ['add-on-tool/PlotCurve.ipynb',


### PR DESCRIPTION
This PR introduces the coding portion of the packaging and delivery of the Plot Curve Add-on via Add-on Manager. This changes in this PR will then be exercised by a build step, as seen [here ](https://teamcity.seeq-labs.com/admin/editRunType.html?id=buildType:AppliedResearch_PlotCurveDeploymentExperimental&runnerId=RUNNER_29&cameFromUrl=%2Fadmin%2FeditBuildRunners.html%3Fid%3DbuildType%253AAppliedResearch_PlotCurveDeploymentExperimental%26init%3D1&cameFromTitle=). Note: this build step will be added to our existing plot-curve build [(here)](https://teamcity.seeq-labs.com/buildConfiguration/AppliedResearch_plot_curve?mode=builds) once this PR merges.

To create a .addon, run `python package.py` from the top directory after pip installing all the requirements in requirements.txt (`pip install -r requirements.txt`). It will produce a `.addon` file in the same directory. 

The work in this PR is very similar to the work done in this [PR](https://github.com/seeq12/seeq-udf-ui/pull/15).