### PR TITLE
CRAB-55452: Fix missing version bump in addon.json

### DIFF
--- a/addon.json
+++ b/addon.json
@@ -2,7 +2,7 @@
   "identifier": "com.seeq.addons.plot_curve",
   "name": "Plot Curve",
   "description": "A tool for fitting curves to tabular data and pushing resulting formulas to Seeq",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "Apache-2.0 license",
   "icon": "fa fa-line-chart",
   "maintainer": "Seeq",


### PR DESCRIPTION
The previous merge to Main omitted the essential version update to 0.1.7 in `addon.json`. 
This PR rectifies the omission.

Team city tests have passed.  

<img width="630" height="279" alt="image" src="https://github.com/user-attachments/assets/eba0c4e7-9f18-4166-b342-af1aa28fa5f2" />
